### PR TITLE
Add a starting Node.js implementation

### DIFF
--- a/nodejs/.gitignore
+++ b/nodejs/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/nodejs/01_monitor.js
+++ b/nodejs/01_monitor.js
@@ -1,0 +1,34 @@
+var config = require('./config'),
+    amqp = require('amqp'),
+    connection = amqp.createConnection(config, { recover: false });
+
+console.log('Opening connection to RabbitMQ host...');
+
+connection.on('ready', function __connectionReady() {
+  console.log('Connected to amqp://' + config.login + ':' + config.password + '@' + config.host + '/' + config.vhost);
+
+  // Connect to exchange
+  var exchange = connection.exchange(config.exchangeName, config.exchange, function __exchangeReady(exchange) {
+    console.log('Exchange \'' + exchange.name + '\' is open');
+  });
+
+  // Setup queue
+  var queue = connection.queue('', config.queue, function __queueReady(queue) {
+    console.log('Queue \'' + queue.name + '\' is open');
+
+    // Bind queue to exchange
+    queue.bind(exchange, '', function __bind() {
+      console.log(' [*] Waiting for solutions on the \'' + config.vhost + '\' bus... To exit press CTRL+C');
+    });
+
+    // Subscribe to messages on queue
+    queue.subscribe(function __listener(message) {
+      // NOTE: if the message was published by another node-amqp client,
+      // message will be a plain JS object, if the message is published by other
+      // clients it may be received as a Buffer, which you'll need to convert
+      // with something like this:
+      // message = JSON.parse(message.data.toString('utf8'));
+      console.log(' [x] Received: ' + JSON.stringify(message));
+    });
+  });
+});

--- a/nodejs/02_needs.js
+++ b/nodejs/02_needs.js
@@ -1,0 +1,23 @@
+var config = require('./config'),
+    amqp = require('amqp'),
+    connection = amqp.createConnection(config, { recover: false }),
+    NeedPackage = require('./NeedPackage');
+
+var publishInterval = 5000;
+
+console.log('Opening connection to RabbitMQ host...');
+
+connection.on('ready', function __connectionReady() {
+  console.log('Connected to amqp://' + config.login + ':' + config.password + '@' + config.host + '/' + config.vhost);
+
+  // Connect to exchange
+  var exchange = connection.exchange(config.exchangeName, config.exchange, function __exchangeReady(exchange) {
+    console.log('Exchange \'' + exchange.name + '\' is open');
+
+    // Publish a NeedPackage on a regular interval
+    setInterval(function __publisher() {
+      exchange.publish('', NeedPackage.create());
+      console.log(' [x] Published a rental offer need on the \'' + config.vhost + '\' bus');
+    }, publishInterval);
+  });
+});

--- a/nodejs/Dockerfile
+++ b/nodejs/Dockerfile
@@ -1,0 +1,20 @@
+# Dockerfile to build a Node.js runtime for Rental Car Offers microservices
+# Version 0.0.1
+
+FROM node:latest
+MAINTAINER Ben Booth <bkbooth@gmail.com>
+
+# Setup application directory
+ENV APP_DIR /usr/src/app/
+RUN mkdir -p ${APP_DIR}
+WORKDIR ${APP_DIR}
+
+# Copy all application files
+COPY . ${APP_DIR}
+
+# Install nodemon
+RUN npm install -g nodemon && \
+    npm cache clear
+
+# Run with nodemon
+CMD nodemon --exec "npm run monitor"

--- a/nodejs/NeedPackage.js
+++ b/nodejs/NeedPackage.js
@@ -1,0 +1,18 @@
+module.exports = {
+  // Create a NeedPackage
+  create: function __create() {
+    return {
+      json_class: "RentalOfferNeed",
+      need: 'car_rental_offer',
+      solutions: []
+    };
+  },
+
+  // Add a solution to an existing NeedPackage
+  addSolution: function __addSolution(package, solution) {
+    // TODO: validate solution?
+    package.solutions.push(solution);
+
+    return package;
+  }
+};

--- a/nodejs/config.js
+++ b/nodejs/config.js
@@ -1,6 +1,6 @@
 module.exports = {
   // RabbitMQ connection
-  host: 'localhost',
+  host: 'rabbitmq',
   vhost: '/',
   login: 'guest',
   password: 'guest',

--- a/nodejs/config.js
+++ b/nodejs/config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  // RabbitMQ connection
+  host: 'localhost',
+  vhost: '/',
+  login: 'guest',
+  password: 'guest',
+
+  // Exchange details
+  exchangeName: 'rapids',
+  exchange: {
+    type: 'fanout',
+    durable: true,
+    autoDelete: false
+  },
+
+  // Queue details
+  queue: {
+    exclusive: true
+  }
+};

--- a/nodejs/docker-compose.yml
+++ b/nodejs/docker-compose.yml
@@ -1,0 +1,23 @@
+# Monitor service
+monitor:
+  build: .
+  command: nodemon --exec "npm run monitor"
+  links:
+    - rabbitmq
+  volumes:
+    - .:/usr/src/app
+
+# Needs service
+needs:
+  build: .
+  command: nodemon --exec "npm run needs"
+  links:
+    - rabbitmq
+  volumes:
+    - .:/usr/src/app
+
+# RabbitMQ with management console exposed
+rabbitmq:
+  image: rabbitmq:management
+  ports:
+    - "15672:15672"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -2,7 +2,8 @@
   "name": "microservice_workshop",
   "private": true,
   "scripts": {
-    "start": "npm run monitor",
+    "start": "docker-compose up",
+    "prestart": "npm install",
     "monitor": "node 01_monitor.js",
     "needs": "node 02_needs.js"
   },

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "microservice_workshop",
+  "main": "01_monitor.js",
+  "dependencies": {
+    "amqp": "^0.2.4"
+  }
+}

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,11 @@
 {
   "name": "microservice_workshop",
-  "main": "01_monitor.js",
+  "private": true,
+  "scripts": {
+    "start": "npm run monitor",
+    "monitor": "node 01_monitor.js",
+    "needs": "node 02_needs.js"
+  },
   "dependencies": {
     "amqp": "^0.2.4"
   }


### PR DESCRIPTION
Includes `Dockerfile` and `docker-compose`. Assuming both are installed, `npm start` installs node dependencies and brings up a RabbitMQ container and two containers for the two initial services (monitor and needs).